### PR TITLE
fixes for the custom keyboard

### DIFF
--- a/sonarr.js
+++ b/sonarr.js
@@ -229,7 +229,6 @@ bot.on('message', function(msg) {
     if (currentState === undefined) {
       replyWithError(chatId, new Error('Try searching for a movie first with `/m movie name`'));
     } else {
-      console.log("currentstate: " + currentState)
       switch(currentState) {
         case state.SERIES:
           var seriesDisplayName = msg.text;
@@ -241,12 +240,10 @@ bot.on('message', function(msg) {
           break;  
         case state.FOLDER:
           var seriesFolderName = msg.text;
-          console.log("seriesFolderName: " + seriesFolderName)
           handleSeriesFolder(chatId, fromId, seriesFolderName);
           break;
         case state.MONITOR:
           var seriesMonitor = msg.text;
-          console.log("seriesmonitor: " + seriesMonitor)
           handleSeriesMonitor(chatId, fromId, seriesMonitor);
           break;            
         default:
@@ -425,8 +422,6 @@ function handleSeriesFolder(chatId, fromId, folderName) {
   
   // set movie option to cache
   cache.set('seriesFolderId' + fromId, folder.folderId);
-  console.log("hSF: " + folder.folderId)
-  console.log(folder)
 
   console.log(fromId + ' requested to get monitor list');
 
@@ -485,42 +480,21 @@ function handleSeriesMonitor(chatId, fromId, monitorType) {
     bot.sendMessage(chatId, 'Oh no! Something went wrong, try searching again');
   }
   
-  console.log("seriesListLen: " + seriesList.length)
-  console.log("profileListLen: " + profileList.length)
-  console.log("folderListLen: " + folderList.length)
-  console.log("monitorListLen: " + monitorList.length)
-    
   var series = _.filter(seriesList, function(item) {
     return item.id == seriesId;
   })[0];
-
-  console.log("series:")
-  console.log(series)
 
   var profile = _.filter(profileList, function(item) {
     return item.id == profileId;
   })[0];
 
-  console.log("profile")
-  console.log(profile)
-
   var folder = _.filter(folderList, function(item) {
     return item.folderId == folderId;
   })[0];
-  
-  console.log("folderId: " + folderId)
-  console.log("folderList")
-  console.log(folderList)
-
-  console.log("folder")
-  console.log(folder)
 
   var monitor = _.filter(monitorList, function(item) {
     return item.type == monitorType;
   })[0];
-  
-  console.log("monitor")
-  console.log(monitor)
   
   var postOpts = {};
   postOpts.tvdbId = series.tvdbId;

--- a/sonarr.js
+++ b/sonarr.js
@@ -229,7 +229,7 @@ bot.on('message', function(msg) {
     if (currentState === undefined) {
       replyWithError(chatId, new Error('Try searching for a movie first with `/m movie name`'));
     } else {
-      console.log(currentState)
+      console.log("currentstate: " + currentState)
       switch(currentState) {
         case state.SERIES:
           var seriesDisplayName = msg.text;
@@ -492,24 +492,28 @@ function handleSeriesMonitor(chatId, fromId, monitorType) {
     return item.id == seriesId;
   })[0];
 
+  console.log("series:")
   console.log(series)
 
   var profile = _.filter(profileList, function(item) {
     return item.id == profileId;
   })[0];
 
+  console.log("profile")
   console.log(profile)
 
   var folder = _.filter(folderList, function(item) {
     return item.id == folderId;
   })[0];
   
+  console.log("folder")
   console.log(folder)
 
   var monitor = _.filter(monitorList, function(item) {
     return item.type == monitorType;
   })[0];
   
+  console.log("monitor")
   console.log(monitor)
   
   var postOpts = {};

--- a/sonarr.js
+++ b/sonarr.js
@@ -222,9 +222,10 @@ bot.on('message', function(msg) {
   var chatId = msg.chat.id;
   var fromId = msg.from.id;
   // If the message is a command, ignore it.
-  if(msg.text[0] != '/') {
+  
+  var currentState = cache.get('state' + fromId);
+  if(msg.text[0] != '/' || (currentState == state.FOLDER && msg.text[0] == '/')) {
     // Check cache to determine state, if cache empty prompt user to start a movie search
-    var currentState = cache.get('state' + fromId);
     if (currentState === undefined) {
       replyWithError(chatId, new Error('Try searching for a movie first with `/m movie name`'));
     } else {
@@ -382,7 +383,7 @@ function handleSeriesProfile(chatId, fromId, profileName) {
       keyboardList.push([n.path])
     });
     response.push('\nPlease select from the menu below.');
-
+    
     // set cache
     cache.set("seriesFolderList" + fromId, folderList);
     cache.set('state' + fromId, state.FOLDER);

--- a/sonarr.js
+++ b/sonarr.js
@@ -505,7 +505,7 @@ function handleSeriesMonitor(chatId, fromId, monitorType) {
   console.log(profile)
 
   var folder = _.filter(folderList, function(item) {
-    return item.id == folderId;
+    return item.folderId == folderId;
   })[0];
   
   console.log("folderId: " + folderId)

--- a/sonarr.js
+++ b/sonarr.js
@@ -425,7 +425,7 @@ function handleSeriesFolder(chatId, fromId, folderName) {
   
   // set movie option to cache
   cache.set('seriesFolderId' + fromId, folder.folderId);
-  console.log("hSF: " + folderId)
+  console.log("hSF: " + folder.folderId)
   console.log(folder)
 
   console.log(fromId + ' requested to get monitor list');

--- a/sonarr.js
+++ b/sonarr.js
@@ -425,6 +425,8 @@ function handleSeriesFolder(chatId, fromId, folderName) {
   
   // set movie option to cache
   cache.set('seriesFolderId' + fromId, folder.folderId);
+  console.log("hSF: " + folderId)
+  console.log(folder)
 
   console.log(fromId + ' requested to get monitor list');
 
@@ -506,6 +508,10 @@ function handleSeriesMonitor(chatId, fromId, monitorType) {
     return item.id == folderId;
   })[0];
   
+  console.log("folderId: " + folderId)
+  console.log("folderList")
+  console.log(folderList)
+
   console.log("folder")
   console.log(folder)
 

--- a/sonarr.js
+++ b/sonarr.js
@@ -229,6 +229,7 @@ bot.on('message', function(msg) {
     if (currentState === undefined) {
       replyWithError(chatId, new Error('Try searching for a movie first with `/m movie name`'));
     } else {
+      console.log(currentState)
       switch(currentState) {
         case state.SERIES:
           var seriesDisplayName = msg.text;
@@ -240,11 +241,12 @@ bot.on('message', function(msg) {
           break;  
         case state.FOLDER:
           var seriesFolderName = msg.text;
+          console.log("seriesFolderName: " + seriesFolderName)
           handleSeriesFolder(chatId, fromId, seriesFolderName);
           break;
         case state.MONITOR:
           var seriesMonitor = msg.text;
-          console.log("seriesmonitor: "+seriesMonitor)
+          console.log("seriesmonitor: " + seriesMonitor)
           handleSeriesMonitor(chatId, fromId, seriesMonitor);
           break;            
         default:

--- a/sonarr.js
+++ b/sonarr.js
@@ -244,6 +244,7 @@ bot.on('message', function(msg) {
           break;
         case state.MONITOR:
           var seriesMonitor = msg.text;
+          console.log("seriesmonitor: "+seriesMonitor)
           handleSeriesMonitor(chatId, fromId, seriesMonitor);
           break;            
         default:
@@ -479,22 +480,35 @@ function handleSeriesMonitor(chatId, fromId, monitorType) {
   if (folderList === undefined || profileList === undefined || seriesList === undefined || monitorList === undefined) {
     bot.sendMessage(chatId, 'Oh no! Something went wrong, try searching again');
   }
+  
+  console.log("seriesListLen: " + seriesList.length)
+  console.log("profileListLen: " + profileList.length)
+  console.log("folderListLen: " + folderList.length)
+  console.log("monitorListLen: " + monitorList.length)
     
   var series = _.filter(seriesList, function(item) {
     return item.id == seriesId;
   })[0];
 
+  console.log(series)
+
   var profile = _.filter(profileList, function(item) {
     return item.id == profileId;
   })[0];
 
+  console.log(profile)
+
   var folder = _.filter(folderList, function(item) {
     return item.id == folderId;
   })[0];
+  
+  console.log(folder)
 
   var monitor = _.filter(monitorList, function(item) {
     return item.type == monitorType;
   })[0];
+  
+  console.log(monitor)
   
   var postOpts = {};
   postOpts.tvdbId = series.tvdbId;


### PR DESCRIPTION
fixes for the custom keyboard where the destination path would start with a '/' such as on OSx and Linux systems. the handler would discard the message thinking it was a command but there wasnt a command waiting to pick it up.

the handler now looks at the current state and if the state is set to FOLDER it will allow the message to pass and be handled by the folder handler.

this also fixes an issue where the folder list `id` was different than the folder's sonarr `id`