### PR TITLE
Modified the 'upcoming'-response:

### DIFF
--- a/modules/SonarrMessage.js
+++ b/modules/SonarrMessage.js
@@ -172,11 +172,17 @@ SonarrMessage.prototype.performCalendarSearch = function(futureDays) {
     if (!episode.length) {
       throw new Error('Nothing in the calendar for the specified time.');
     }
-
+    
+    var lastDate = null;
     var response = [];
     _.forEach(episode, function(n, key) {
       var done = (n.hasFile ? ' - *Done*' : '');
-      response.push(n.series.title + ' - '  + n.airDate + done);
+
+      // Add an empty line to break list of multiple days
+      if(lastDate != null && n.airDate != lastDate) response.push(' ');
+
+      response.push(n.airDate + ' - ' + n.series.title + done);
+      lastDate = n.airDate;
     });
 
     logger.info('user: %s, message: found the following series %s', self.username, response.join(','));


### PR DESCRIPTION
- Date first; the list is now better alligned and readable.
- Split days with an empty line.

This will be shown like this now:

> 2016-04-03 - The Walking Dead
2016-04-03 - The Family (2016)
2016-04-03 - Quantico
2016-04-03 - Billions
> 
> 2016-04-04 - 11.22.63
2016-04-04 - Damien
2016-04-04 - Blindspot
2016-04-04 - Better Call Saul
2016-04-04 - Teen Mom 2